### PR TITLE
Db relationships

### DIFF
--- a/db/migrate/20220530090107_remove_itemidand_invoice_id_from_invoice_items.rb
+++ b/db/migrate/20220530090107_remove_itemidand_invoice_id_from_invoice_items.rb
@@ -1,0 +1,10 @@
+class RemoveItemidandInvoiceIdFromInvoiceItems < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :invoice_items, :item_id, :integer
+    remove_column :invoice_items, :invoice_id, :integer
+  end
+  def down
+    add_column :invoice_items, :item_id, :integer
+    add_column :invoice_items, :invoice_id, :integer
+  end
+end

--- a/db/migrate/20220530090557_remove_customerid_from_invoices.rb
+++ b/db/migrate/20220530090557_remove_customerid_from_invoices.rb
@@ -1,0 +1,8 @@
+class RemoveCustomeridFromInvoices < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :invoices, :customer_id, :integer
+  end
+  def down
+    add_column :invoices, :customer_id, :integer
+  end
+end

--- a/db/migrate/20220530090702_remove_merchantid_from_items.rb
+++ b/db/migrate/20220530090702_remove_merchantid_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveMerchantidFromItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :items, :merchant_id, :integer
+  end
+end

--- a/db/migrate/20220530090748_remove_invoiceid_from_transactions.rb
+++ b/db/migrate/20220530090748_remove_invoiceid_from_transactions.rb
@@ -1,0 +1,5 @@
+class RemoveInvoiceidFromTransactions < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :transactions, :invoice_id, :integer
+  end
+end

--- a/db/migrate/20220530091221_add_merchant_ref_to_items.rb
+++ b/db/migrate/20220530091221_add_merchant_ref_to_items.rb
@@ -1,0 +1,8 @@
+class AddMerchantRefToItems < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :items, :merchant, foreign_key: true
+  end
+  def down
+    remove_reference :items, :merchant, foreign_key: true
+  end
+end

--- a/db/migrate/20220530091328_add_invoice_ref_and_item_ref_to_invoice_items.rb
+++ b/db/migrate/20220530091328_add_invoice_ref_and_item_ref_to_invoice_items.rb
@@ -1,0 +1,10 @@
+class AddInvoiceRefAndItemRefToInvoiceItems < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :invoice_items, :invoice, foreign_key: true
+    add_reference :invoice_items, :item, foreign_key: true
+  end
+  def down
+    remove_reference :invoice_items, :invoice, foreign_key: true
+    remove_reference :invoice_items, :item, foreign_key: true
+  end
+end

--- a/db/migrate/20220530091416_add_invoice_ref_to_transactions.rb
+++ b/db/migrate/20220530091416_add_invoice_ref_to_transactions.rb
@@ -1,0 +1,8 @@
+class AddInvoiceRefToTransactions < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :transactions, :invoice, foreign_key: true
+  end
+  def down
+    remove_reference :transactions, :invoice, foreign_key: true
+  end
+end

--- a/db/migrate/20220530091649_add_invoices_to_customer.rb
+++ b/db/migrate/20220530091649_add_invoices_to_customer.rb
@@ -1,0 +1,8 @@
+class AddInvoicesToCustomer < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :customers, :invoice, foreign_key: true
+  end
+  def down
+    remove_reference :customers, :invoice, foreign_key: true
+  end
+end

--- a/db/migrate/20220530091649_add_invoices_to_customer.rb
+++ b/db/migrate/20220530091649_add_invoices_to_customer.rb
@@ -1,8 +1,0 @@
-class AddInvoicesToCustomer < ActiveRecord::Migration[5.2]
-  def up
-    add_reference :customers, :invoice, foreign_key: true
-  end
-  def down
-    remove_reference :customers, :invoice, foreign_key: true
-  end
-end

--- a/db/migrate/20220530092441_add_customer_to_invoices.rb
+++ b/db/migrate/20220530092441_add_customer_to_invoices.rb
@@ -1,0 +1,8 @@
+class AddCustomerToInvoices < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :invoices, :customer, foreign_key: true
+  end
+  def down
+    remove_reference :invoices, :customer, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_30_091649) do
+ActiveRecord::Schema.define(version: 2022_05_30_092441) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,8 +20,6 @@ ActiveRecord::Schema.define(version: 2022_05_30_091649) do
     t.string "last_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "invoice_id"
-    t.index ["invoice_id"], name: "index_customers_on_invoice_id"
   end
 
   create_table "invoice_items", force: :cascade do |t|
@@ -40,6 +38,8 @@ ActiveRecord::Schema.define(version: 2022_05_30_091649) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "customer_id"
+    t.index ["customer_id"], name: "index_invoices_on_customer_id"
   end
 
   create_table "items", force: :cascade do |t|
@@ -68,9 +68,9 @@ ActiveRecord::Schema.define(version: 2022_05_30_091649) do
     t.index ["invoice_id"], name: "index_transactions_on_invoice_id"
   end
 
-  add_foreign_key "customers", "invoices"
   add_foreign_key "invoice_items", "invoices"
   add_foreign_key "invoice_items", "items"
+  add_foreign_key "invoices", "customers"
   add_foreign_key "items", "merchants"
   add_foreign_key "transactions", "invoices"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_27_235504) do
+ActiveRecord::Schema.define(version: 2022_05_30_090748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,8 +23,6 @@ ActiveRecord::Schema.define(version: 2022_05_27_235504) do
   end
 
   create_table "invoice_items", force: :cascade do |t|
-    t.integer "item_id"
-    t.integer "invoice_id"
     t.integer "quantity"
     t.integer "unit_price"
     t.string "status"
@@ -33,7 +31,6 @@ ActiveRecord::Schema.define(version: 2022_05_27_235504) do
   end
 
   create_table "invoices", force: :cascade do |t|
-    t.integer "customer_id"
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -43,7 +40,6 @@ ActiveRecord::Schema.define(version: 2022_05_27_235504) do
     t.string "name"
     t.string "description"
     t.integer "unit_price"
-    t.integer "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -55,7 +51,6 @@ ActiveRecord::Schema.define(version: 2022_05_27_235504) do
   end
 
   create_table "transactions", force: :cascade do |t|
-    t.integer "invoice_id"
     t.string "credit_card_number"
     t.string "credit_card_expiration_date"
     t.string "result"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_30_090748) do
+ActiveRecord::Schema.define(version: 2022_05_30_091649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 2022_05_30_090748) do
     t.string "last_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "invoice_id"
+    t.index ["invoice_id"], name: "index_customers_on_invoice_id"
   end
 
   create_table "invoice_items", force: :cascade do |t|
@@ -28,6 +30,10 @@ ActiveRecord::Schema.define(version: 2022_05_30_090748) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "invoice_id"
+    t.bigint "item_id"
+    t.index ["invoice_id"], name: "index_invoice_items_on_invoice_id"
+    t.index ["item_id"], name: "index_invoice_items_on_item_id"
   end
 
   create_table "invoices", force: :cascade do |t|
@@ -42,6 +48,8 @@ ActiveRecord::Schema.define(version: 2022_05_30_090748) do
     t.integer "unit_price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "merchant_id"
+    t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 
   create_table "merchants", force: :cascade do |t|
@@ -56,6 +64,13 @@ ActiveRecord::Schema.define(version: 2022_05_30_090748) do
     t.string "result"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "invoice_id"
+    t.index ["invoice_id"], name: "index_transactions_on_invoice_id"
   end
 
+  add_foreign_key "customers", "invoices"
+  add_foreign_key "invoice_items", "invoices"
+  add_foreign_key "invoice_items", "items"
+  add_foreign_key "items", "merchants"
+  add_foreign_key "transactions", "invoices"
 end


### PR DESCRIPTION
We created our tables with incorrect columns for establishing relationships (Ex. We created Invoice_Items with a column Item_id as an integer.) We needed to create an association between the tables Invoice_Items and Items by assigning a foreign_id within Invoice_Items that is connected to the Primary ID of Items. I've created a series of migrations that removed the incorrect columns and then migrations to install the appropriate foreign keys. I created them so they are all reversible through db:rollback in the event this correction is not correct.